### PR TITLE
fix: set headers for built assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -18,3 +18,24 @@
 
 /*.ico
   Content-Type: image/x-icon
+
+/assets/*.js
+  Content-Type: application/javascript
+
+/assets/*.mjs
+  Content-Type: application/javascript
+
+/assets/*.ts
+  Content-Type: application/javascript
+
+/assets/*.tsx
+  Content-Type: application/javascript
+
+/assets/*.css
+  Content-Type: text/css
+
+/assets/*.svg
+  Content-Type: image/svg+xml
+
+/assets/*.ico
+  Content-Type: image/x-icon


### PR DESCRIPTION
## Summary
- ensure build output assets have proper Content-Type headers

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d935750832a954694fb438a4b0b