### PR TITLE
Remove TypeScript headers from static configuration

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,12 +4,6 @@
 /*.mjs
   Content-Type: application/javascript
 
-/*.ts
-  Content-Type: application/javascript
-
-/*.tsx
-  Content-Type: application/javascript
-
 /*.css
   Content-Type: text/css
 
@@ -23,12 +17,6 @@
   Content-Type: application/javascript
 
 /assets/*.mjs
-  Content-Type: application/javascript
-
-/assets/*.ts
-  Content-Type: application/javascript
-
-/assets/*.tsx
   Content-Type: application/javascript
 
 /assets/*.css


### PR DESCRIPTION
## Summary
- remove `/*.ts` and `/*.tsx` headers to prevent serving TypeScript files
- drop `assets` TypeScript header rules

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)


------
https://chatgpt.com/codex/tasks/task_e_68b11e58a814832aaa57bb23172d8452