### PR TITLE
chore: add trailing newline to headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -27,3 +27,4 @@
 
 /assets/*.ico
   Content-Type: image/x-icon
+


### PR DESCRIPTION
## Summary
- ensure `public/_headers` ends with a blank line so final header entry is terminated correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b11fe19008832a97b438840a5f7958