### PR TITLE
fix: add TypeScript MIME headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -13,6 +13,30 @@
 /*.ico
   Content-Type: image/x-icon
 
+/*.ts
+  Content-Type: application/javascript
+
+/*.tsx
+  Content-Type: application/javascript
+
+/src/*.ts
+  Content-Type: application/javascript
+
+/src/*.tsx
+  Content-Type: application/javascript
+
+/src/*/*.ts
+  Content-Type: application/javascript
+
+/src/*/*.tsx
+  Content-Type: application/javascript
+
+/src/*.css
+  Content-Type: text/css
+
+/src/*/*.css
+  Content-Type: text/css
+
 /assets/*.js
   Content-Type: application/javascript
 


### PR DESCRIPTION
## Summary
- ensure TypeScript and CSS files served from `src` receive correct Content-Type headers to avoid MIME errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68b12373a7ec832abafe647c7ffeb437