### PR TITLE
fix: handle reset tokens from URL hash

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -34,14 +34,15 @@ export const ResetPassword: React.FC = () => {
   const isPasswordStrong = passwordStrength.score >= 4;
 
   useEffect(() => {
-    // Check if we have the required tokens from the URL
-    const accessToken = searchParams.get('access_token');
-    const refreshToken = searchParams.get('refresh_token');
-
     if (!APP_CONFIG.ENABLE_REAL_AUTH) {
       // Mock mode - allow password reset
       return;
     }
+
+    // Supabase sends reset tokens in the URL hash (#) rather than the query string
+    const hashParams = new URLSearchParams(window.location.hash.substring(1));
+    const accessToken = searchParams.get('access_token') || hashParams.get('access_token');
+    const refreshToken = searchParams.get('refresh_token') || hashParams.get('refresh_token');
 
     if (!accessToken || !refreshToken) {
       setError('Invalid or expired reset link. Please request a new password reset.');


### PR DESCRIPTION
## Summary
- fix reset password flow by reading Supabase tokens from URL hash when present

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TS6133 unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b20560b654832a806e961e0e6d3466