### PR TITLE
Fix Netlify build and add favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/png" href="/Freedom Lab_Favicon copy.png" />
+    <link rel="icon" href="/favicon.ico" />
     <title>TestiFlow - Testimonial Management Platform</title>
   </head>
   <body>

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -93,26 +93,6 @@ export const ExportModal: React.FC<ExportModalProps> = ({ testimonials, onClose,
     }
   };
 
-  const generatePreview = () => {
-    switch (selectedFormat) {
-      case 'social':
-        if (selectedTestimonials.length === 1) {
-          const testimonial = statusFilteredTestimonials.find(t => t.id === selectedTestimonials[0]);
-          if (testimonial) {
-            return generateSocialMediaPost(testimonial);
-          }
-        }
-        return '';
-      case 'widget':
-        return generateWebsiteWidget(
-          widgetTestimonials, 
-          branding?.primary_color || '#01004d', 
-          branding?.secondary_color || '#01b79e'
-        );
-      default:
-        return '';
-    }
-  };
 
   const handleExport = () => {
     switch (selectedFormat) {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, X, User, LogOut } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';

--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TestiFlowIcon } from '../components/TestiFlowIcon';
-import { User, LogOut, Plus, Settings, Eye, Copy, ExternalLink, Star, Download, FileText, Code, Send, CheckCircle, X, ArrowUp, ArrowDown } from 'lucide-react';
+import { User, LogOut, Plus, Settings, Copy, ExternalLink, Star, Download, FileText, Code, Send, ArrowUp, ArrowDown } from 'lucide-react';
 
 interface DemoStep {
   id: string;

--- a/src/pages/Forms.tsx
+++ b/src/pages/Forms.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useSubscription, canCreateForm } from '../hooks/useSubscription';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { supabase } from '../lib/supabase';
-import { Plus, Edit, Trash2, ExternalLink, Copy, Eye, Settings, X, Calendar, ToggleLeft, ToggleRight, FileText, Image, Video } from 'lucide-react';
+import { Plus, Edit, Trash2, ExternalLink, Copy, Eye, Settings, X, Calendar, ToggleLeft, ToggleRight, FileText } from 'lucide-react';
 import { Alert } from '../components/Alert';
 import { FormBuilder } from '../components/FormBuilder';
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -129,7 +129,7 @@ export const Settings: React.FC = () => {
                         <span className="px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800">
                           {getCurrentPlan()?.name || 'Unknown Plan'}
                         </span>
-                        <span className="text-sm text-gray-500">${getCurrentPlan()?.price}/mo</span>
+                        {/* Price information is not available in product data */}
                       </div>
                     </div>
                     <div className="flex items-center justify-between">

--- a/src/pages/SubmitTestimonial.tsx
+++ b/src/pages/SubmitTestimonial.tsx
@@ -312,7 +312,7 @@ export const SubmitTestimonial: React.FC = () => {
         .single();
 
       if (error || !testimonialData) {
-        if (error.code === 'PGRST116') {
+        if (error && error.code === 'PGRST116') {
           console.log('No form found with ID:', formId);
           setError('Form not found or inactive');
         } else {

--- a/src/pages/Testimonials.tsx
+++ b/src/pages/Testimonials.tsx
@@ -4,7 +4,7 @@ import { useSubscription } from '../hooks/useSubscription';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { TestimonialTagger } from '../components/TestimonialTagger';
 import { supabase } from '../lib/supabase';
-import { MessageSquare, Star, User, CheckCircle, Clock, X, Download, Trash2, MoreVertical, Eye, Mail, Building, Tag, Filter } from 'lucide-react';
+import { MessageSquare, Star, User, CheckCircle, Clock, X, Download, Trash2, MoreVertical, Eye, Mail, Building, Filter } from 'lucide-react';
 import { Alert } from '../components/Alert';
 import { ExportModal } from '../components/ExportModal';
 import { ExportTestimonial } from '../utils/exportUtils';

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -10,6 +10,8 @@ export interface ExportTestimonial {
   submitted_at: string;
   form_title: string;
   custom_responses?: Record<string, string>;
+  image_url?: string;
+  video_url?: string;
 }
 
 export const exportToCSV = (testimonials: ExportTestimonial[], filename: string = 'testimonials') => {


### PR DESCRIPTION
## Summary
- clean up unused imports and fix type definitions so `tsc` completes
- handle potential null errors and remove unused price reference
- reference `favicon.ico` so the icon displays on deployed site

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b68d2431ec832a8c189e4336e1a409