### PR TITLE
Add subscription loading state and guard gated features

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -159,6 +159,16 @@ export const ExportModal: React.FC<ExportModalProps> = ({ testimonials, onClose,
     }
   };
 
+  if (subscription.loading) {
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="bg-white rounded-lg p-6">
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-950"></div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg w-full max-w-6xl max-h-[90vh] overflow-hidden">

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -49,7 +49,11 @@ const PLAN_LIMITS: Record<'standard' | 'premium', SubscriptionLimits> = {
   },
 };
 
-export const useSubscription = (): SubscriptionInfo => {
+export interface SubscriptionState extends SubscriptionInfo {
+  loading: boolean;
+}
+
+export const useSubscription = (): SubscriptionState => {
   const { user } = useAuth();
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo>({
@@ -63,6 +67,7 @@ export const useSubscription = (): SubscriptionInfo => {
       formCount: 0,
     },
   });
+  const [loading, setLoading] = useState(true);
 
   // Function to manually refresh subscription data
   const refreshSubscription = () => {
@@ -79,7 +84,11 @@ export const useSubscription = (): SubscriptionInfo => {
 
   useEffect(() => {
     const fetchSubscriptionInfo = async () => {
-      if (!user) return;
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
 
       try {
         console.log('Fetching subscription info for user:', user.id);
@@ -198,24 +207,27 @@ export const useSubscription = (): SubscriptionInfo => {
           limits: limits,
           currentUsage: { testimonialCount, formCount }
         });
-      } catch (error) {
-        console.error('Error fetching subscription info:', error);
-        // On error, default to Standard limits
-        setSubscriptionInfo(prev => ({
-          ...prev,
-          limits: PLAN_LIMITS.standard,
-        }));
-      }
-    };
+        } catch (error) {
+          console.error('Error fetching subscription info:', error);
+          // On error, default to Standard limits
+          setSubscriptionInfo(prev => ({
+            ...prev,
+            limits: PLAN_LIMITS.standard,
+          }));
+        } finally {
+          setLoading(false);
+        }
+      };
 
-    fetchSubscriptionInfo();
+      fetchSubscriptionInfo();
    }, [user, refreshTrigger]);
 
-  return subscriptionInfo;
+  return { ...subscriptionInfo, loading };
 };
 
 // Helper functions for feature gating
-export const canCreateForm = (subscription: SubscriptionInfo): boolean => {
+export const canCreateForm = (subscription: SubscriptionState): boolean => {
+  if (subscription.loading) return true;
   // During trial or active subscription, enforce plan limits
   if (subscription.isActive || subscription.isTrialing) {
     return subscription.currentUsage.formCount < subscription.limits.maxForms;
@@ -224,7 +236,8 @@ export const canCreateForm = (subscription: SubscriptionInfo): boolean => {
   return false;
 };
 
-export const canCreateTestimonial = (subscription: SubscriptionInfo): boolean => {
+export const canCreateTestimonial = (subscription: SubscriptionState): boolean => {
+  if (subscription.loading) return true;
   return subscription.currentUsage.testimonialCount < subscription.limits.maxTestimonials;
 };
 

--- a/src/pages/Branding.tsx
+++ b/src/pages/Branding.tsx
@@ -40,7 +40,7 @@ export const Branding: React.FC = () => {
   const { user } = useAuth();
   const subscription = useSubscription();
   const [, setBranding] = useState<FormBranding | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [brandingLoading, setBrandingLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -56,11 +56,13 @@ export const Branding: React.FC = () => {
     fetchBranding();
   }, [user]);
 
-  const fetchBranding = async () => {
-    if (!user) return;
+    const fetchBranding = async () => {
+      if (!user) return;
 
-    try {
-      const { data, error } = await supabase
+      setBrandingLoading(true);
+
+      try {
+        const { data, error } = await supabase
         .from('form_branding')
         .select('*')
         .eq('user_id', user.id)
@@ -78,13 +80,13 @@ export const Branding: React.FC = () => {
         setFontFamily(data.font_family);
       }
       
-      setLoading(false);
-    } catch (error) {
-      console.error('Error fetching branding:', error);
-      setError('Failed to load branding settings');
-      setLoading(false);
-    }
-  };
+        setBrandingLoading(false);
+      } catch (error) {
+        console.error('Error fetching branding:', error);
+        setError('Failed to load branding settings');
+        setBrandingLoading(false);
+      }
+    };
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -175,7 +177,7 @@ export const Branding: React.FC = () => {
     }
   };
 
-  if (loading) {
+  if (brandingLoading || subscription.loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-950"></div>

--- a/src/pages/Forms.tsx
+++ b/src/pages/Forms.tsx
@@ -26,7 +26,7 @@ export const Forms: React.FC = () => {
   const { user } = useAuth();
   const subscription = useSubscription();
   const [forms, setForms] = useState<TestimonialForm[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [formsLoading, setFormsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -82,7 +82,7 @@ export const Forms: React.FC = () => {
       console.error('Error fetching forms:', error);
       setError('Failed to load forms');
     } finally {
-      setLoading(false);
+        setFormsLoading(false);
     }
   };
 
@@ -266,7 +266,7 @@ export const Forms: React.FC = () => {
     setShowCreateForm(true);
   };
 
-  if (loading) {
+  if (formsLoading || subscription.loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-950"></div>

--- a/src/pages/Tags.tsx
+++ b/src/pages/Tags.tsx
@@ -6,6 +6,14 @@ import { TagManager } from '../components/TagManager';
 export const Tags: React.FC = () => {
   const subscription = useSubscription();
 
+  if (subscription.loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-950"></div>
+      </div>
+    );
+  }
+
   // Show upgrade prompt for Standard users
   if (!subscription.limits.canUseTags) {
     return (

--- a/src/pages/Testimonials.tsx
+++ b/src/pages/Testimonials.tsx
@@ -53,7 +53,7 @@ export const Testimonials: React.FC = () => {
   const [tags, setTags] = useState<TestimonialTag[]>([]);
   const [testimonialTags, setTestimonialTags] = useState<Record<string, TestimonialTag[]>>({});
   const [testimonialResponses, setTestimonialResponses] = useState<Record<string, FormResponse[]>>({});
-  const [loading, setLoading] = useState(true);
+  const [dataLoading, setDataLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all');
   const [tagFilter, setTagFilter] = useState<string>('all');
@@ -77,12 +77,16 @@ export const Testimonials: React.FC = () => {
       return () => document.removeEventListener('mousedown', handleClickOutside);
     }
   }, [showActionsFor]);
-  useEffect(() => {
-    fetchData();
-  }, [user]);
+    useEffect(() => {
+      if (!subscription.loading) {
+        fetchData();
+      }
+    }, [user, subscription.loading]);
 
   const fetchData = async () => {
     if (!user) return;
+
+    setDataLoading(true);
 
     try {
       setError(null);
@@ -184,11 +188,11 @@ export const Testimonials: React.FC = () => {
         }
       }
 
-      setLoading(false);
+      setDataLoading(false);
     } catch (error) {
       console.error('Error fetching testimonials:', error);
       setError('Failed to load testimonials');
-      setLoading(false);
+      setDataLoading(false);
     }
   };
 
@@ -327,7 +331,7 @@ export const Testimonials: React.FC = () => {
 
   const filteredTestimonials = getFilteredTestimonials();
 
-  if (loading) {
+  if (dataLoading || subscription.loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-950"></div>


### PR DESCRIPTION
## Summary
- add `loading` to subscription hook and expose with subscription info
- defer plan checks in gating helpers while subscription is loading
- show spinners in subscription-based pages and modal until plan data loads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c1cd77cb3c832ab5286feae249a5b3