### PR TITLE
Avoid double parsing of request body in stripe checkout

### DIFF
--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -52,8 +52,16 @@ Deno.serve(async (req) => {
       return corsResponse({ error: 'Stripe is not configured. Please set STRIPE_SECRET_KEY environment variable.' }, 500);
     }
 
-    const { price_id, success_url, cancel_url, mode, customer_email, client_reference_id, is_plan_change } = await req.json();
-    const { has_trial = true } = await req.json();
+    const {
+      price_id,
+      success_url,
+      cancel_url,
+      mode,
+      customer_email,
+      client_reference_id,
+      is_plan_change,
+      has_trial = true,
+    } = await req.json();
 
     // CRITICAL: Prevent plan changes through this endpoint
     if (is_plan_change) {


### PR DESCRIPTION
## Summary
- Avoid parsing request payload twice by destructuring `has_trial` in the initial `req.json()` call

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c4af0a6e70832a95d42ba19040d4ac