### PR TITLE
Validate Stripe checkout client reference id

### DIFF
--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -70,16 +70,17 @@ Deno.serve(async (req) => {
       }, 400);
     }
 
-    const error = validateParameters(
-      { price_id, success_url, cancel_url, mode, customer_email },
-      {
-        cancel_url: 'string',
-        price_id: 'string',
-        success_url: 'string',
-        customer_email: 'string',
-        mode: { values: ['payment', 'subscription'] },
-      },
-    );
+      const error = validateParameters(
+        { price_id, success_url, cancel_url, mode, customer_email, client_reference_id },
+        {
+          cancel_url: 'string',
+          price_id: 'string',
+          success_url: 'string',
+          customer_email: 'string',
+          client_reference_id: 'string',
+          mode: { values: ['payment', 'subscription'] },
+        },
+      );
 
     if (error) {
       return corsResponse({ error }, 400);


### PR DESCRIPTION
## Summary
- validate `client_reference_id` for Stripe checkout sessions to ensure sessions map to internal users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aff6ff14832a80e2aad1d9e49e47