### PR TITLE
Configure Outseta public key via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # freedomlab-testiflow
+
+## Environment Setup
+
+Make sure your build system (e.g., Netlify, local `.env` files) provides the following environment variables so Outseta can initialize correctly:
+
+- `VITE_OUTSETA_DOMAIN`
+- `VITE_OUTSETA_PUBLIC_KEY`
+
+The `.env.example` file lists all required values for reference.

--- a/index.html
+++ b/index.html
@@ -2,12 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <script>
-    var o_options = {
+    <script type="module">
+      const { VITE_OUTSETA_PUBLIC_KEY } = import.meta.env;
+
+      if (!VITE_OUTSETA_PUBLIC_KEY) {
+        console.warn('Outseta public key is not set. Authentication widgets may not load.');
+      }
+
+      window.o_options = {
         domain: 'freedomlab.outseta.com',
-        load: 'auth,customForm,emailList,leadCapture,nocode,profile,support',
-        publicKey: 'a8d84378-6ceb-47ce-99a7-9d91e9a0bdc4'
-    };
+        publicKey: VITE_OUTSETA_PUBLIC_KEY,
+        load: 'auth,customForm,emailList,leadCapture,nocode,profile,support'
+      };
     </script>
     <script src="https://cdn.outseta.com/outseta.min.js"
             data-options="o_options">


### PR DESCRIPTION
## Summary
- load the Outseta widget configuration from `VITE_OUTSETA_PUBLIC_KEY` instead of a hard-coded key
- surface a console warning when the key is missing so deployment misconfigurations are easier to spot
- document the required Outseta environment variables in the project README

## Testing
- `npm run build` *(fails: existing TypeScript errors throughout the project unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c8882b6ad4832ab4237857ab40244b