### PR TITLE
Ensure Outseta script loads after defining embed options

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,48 @@
   <head>
     <meta charset="UTF-8" />
     <script type="module">
-      const { VITE_OUTSETA_PUBLIC_KEY } = import.meta.env;
+      const DEFAULT_DOMAIN = 'freedomlab.outseta.com';
+      const {
+        VITE_OUTSETA_DOMAIN,
+        VITE_OUTSETA_PUBLIC_KEY
+      } = import.meta.env;
 
-      if (!VITE_OUTSETA_PUBLIC_KEY) {
-        console.warn('Outseta public key is not set. Authentication widgets may not load.');
+      const domain = (VITE_OUTSETA_DOMAIN || DEFAULT_DOMAIN).trim();
+      const publicKey = (VITE_OUTSETA_PUBLIC_KEY || '').trim();
+
+      if (!domain) {
+        console.error(
+          '[Outseta] Domain is not configured. Set VITE_OUTSETA_DOMAIN or update the default domain so authentication widgets can load.'
+        );
+      }
+
+      if (!publicKey) {
+        console.warn(
+          '[Outseta] Public key is not set. Authentication widgets may not load until VITE_OUTSETA_PUBLIC_KEY is configured.'
+        );
       }
 
       window.o_options = {
-        domain: 'freedomlab',
-        publicKey: VITE_OUTSETA_PUBLIC_KEY,
+        domain,
+        publicKey,
         load: 'auth,customForm,emailList,leadCapture,nocode,profile,support'
       };
-    </script>
-    <script src="https://cdn.outseta.com/outseta.min.js"
-            data-options="o_options">
+
+      const ensureOutsetaScript = () => {
+        if (document.getElementById('outseta-script')) {
+          return;
+        }
+
+        const script = document.createElement('script');
+        script.id = 'outseta-script';
+        script.src = 'https://cdn.outseta.com/outseta.min.js';
+        script.dataset.options = 'o_options';
+        document.head.appendChild(script);
+      };
+
+      if (domain) {
+        ensureOutsetaScript();
+      }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/lib/outseta.ts
+++ b/src/lib/outseta.ts
@@ -52,8 +52,8 @@ export type EntitlementStatus =
 
 // Outseta configuration
 export const OUTSETA_CONFIG = {
-  domain: 'freedomlab.outseta.com',
-  publicKey: import.meta.env.VITE_OUTSETA_PUBLIC_KEY || '',
+  domain: (import.meta.env.VITE_OUTSETA_DOMAIN || 'freedomlab.outseta.com').trim(),
+  publicKey: (import.meta.env.VITE_OUTSETA_PUBLIC_KEY || '').trim(),
 };
 
 // TestiFlow plan configuration


### PR DESCRIPTION
## Summary
- define Outseta embed options from environment values, warn when configuration is missing, and dynamically inject the CDN script after the options exist so the required domain setting is picked up
- trim and reuse the configured domain and public key inside the Outseta TypeScript helpers to keep the runtime values consistent

## Testing
- npm run lint *(fails: ESLint 9.x expects an eslint.config.js flat config while the project still uses .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c886e2cf24832a94852b1a502acd34