### PR TITLE
Make Outseta configuration environment-driven

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <script type="module">
-      const { VITE_OUTSETA_PUBLIC_KEY } = import.meta.env;
+      const { VITE_OUTSETA_DOMAIN, VITE_OUTSETA_PUBLIC_KEY } = import.meta.env;
+
+      const sanitizeDomain = (domain) => domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+      const resolvedDomain = VITE_OUTSETA_DOMAIN ? sanitizeDomain(VITE_OUTSETA_DOMAIN) : 'freedomlab.outseta.com';
+
+      if (!VITE_OUTSETA_DOMAIN) {
+        console.warn('Outseta domain is not set. Authentication widgets may not load.');
+      }
 
       if (!VITE_OUTSETA_PUBLIC_KEY) {
         console.warn('Outseta public key is not set. Authentication widgets may not load.');
       }
 
       window.o_options = {
-        domain: 'https://freedomlab.outseta.com',
-        publicKey: VITE_OUTSETA_PUBLIC_KEY,
+        domain: `https://${resolvedDomain}`,
+        publicKey: VITE_OUTSETA_PUBLIC_KEY || '',
         load: 'auth,customForm,emailList,leadCapture,nocode,profile,support'
       };
     </script>

--- a/src/contexts/OutsetaAuthContext.tsx
+++ b/src/contexts/OutsetaAuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { getOutsetaUser, getOutsetaJWT, requireEntitlement, syncUserToSupabase, triggerLogout, initializeOutseta, TESTIFLOW_PLAN } from '../lib/outseta';
+import { getOutsetaUser, getOutsetaJWT, requireEntitlement, syncUserToSupabase, triggerLogout, initializeOutseta, TESTIFLOW_PLAN, OUTSETA_CONFIG } from '../lib/outseta';
 
 interface OutsetaUser {
   uid: string;
@@ -57,7 +57,7 @@ export const OutsetaAuthProvider: React.FC<{ children: React.ReactNode }> = ({ c
       
       // Listen for auth state changes from Outseta embeds
       const handleMessage = (event: MessageEvent) => {
-        if (event.origin !== `https://freedomlab.outseta.com`) return;
+        if (event.origin !== OUTSETA_CONFIG.origin) return;
         
         if (event.data.type === 'outseta.auth.login' || event.data.type === 'outseta.auth.register') {
           console.log('OutsetaAuth: Auth event received, refreshing state');

--- a/src/lib/outseta.ts
+++ b/src/lib/outseta.ts
@@ -50,15 +50,22 @@ export type EntitlementStatus =
   | 'BLOCKED' 
   | 'NO_ENTITLEMENT';
 
+const sanitizeDomain = (domain: string) => domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
+const rawDomain = import.meta.env.VITE_OUTSETA_DOMAIN || 'freedomlab.outseta.com';
+const normalizedDomain = sanitizeDomain(rawDomain);
+const outsetaOrigin = `https://${normalizedDomain}`;
+
 // Outseta configuration
 export const OUTSETA_CONFIG = {
-  domain: 'freedomlab.outseta.com',
+  domain: normalizedDomain,
+  origin: outsetaOrigin,
   publicKey: import.meta.env.VITE_OUTSETA_PUBLIC_KEY || '',
 };
 
 // TestiFlow plan configuration
 export const TESTIFLOW_PLAN = {
-  uid: 'jW78klmq',
+  uid: import.meta.env.VITE_OUTSETA_STANDARD_PLAN_UID || 'jW78klmq',
   slug: 'testiflow-standard',
   name: 'TestiFlow Standard',
 };
@@ -66,6 +73,13 @@ export const TESTIFLOW_PLAN = {
 // Initialize Outseta script with proper configuration
 export const initializeOutseta = (): Promise<void> => {
   if (typeof window === 'undefined') return Promise.resolve();
+
+  if (window.o_options) {
+    window.o_options.domain = OUTSETA_CONFIG.origin;
+    if (OUTSETA_CONFIG.publicKey) {
+      window.o_options.publicKey = OUTSETA_CONFIG.publicKey;
+    }
+  }
 
   return new Promise((resolve) => {
     // Check if Outseta is fully loaded

--- a/src/pages/BillingUpdate.tsx
+++ b/src/pages/BillingUpdate.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { AlertCircle, CreditCard } from 'lucide-react';
 import { TestiFlowIcon } from '../components/TestiFlowIcon';
-import { initializeOutseta } from '../lib/outseta';
+import { initializeOutseta, OUTSETA_CONFIG } from '../lib/outseta';
 import { useOutsetaAuth } from '../contexts/OutsetaAuthContext';
 
 export const BillingUpdate: React.FC = () => {
@@ -16,7 +16,7 @@ export const BillingUpdate: React.FC = () => {
 
     // Listen for billing updates
     const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== 'https://freedomlab.outseta.com') return;
+      if (event.origin !== OUTSETA_CONFIG.origin) return;
       
       if (event.data.type === 'outseta.profile.updated') {
         console.log('Billing updated, refreshing auth state');

--- a/src/pages/OutsetaPricing.tsx
+++ b/src/pages/OutsetaPricing.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Check } from 'lucide-react';
 import { TestiFlowIcon } from '../components/TestiFlowIcon';
-import { initializeOutseta } from '../lib/outseta';
+import { initializeOutseta, TESTIFLOW_PLAN } from '../lib/outseta';
 
 export const OutsetaPricing: React.FC = () => {
   useEffect(() => {
@@ -72,7 +72,7 @@ export const OutsetaPricing: React.FC = () => {
             <div 
               data-o-auth="1"
               data-widget-mode="register"
-              data-plan-uid="jW78klmq"
+              data-plan-uid={TESTIFLOW_PLAN.uid}
               data-plan-payment-term="month"
               data-skip-plan-options="true"
               data-require-payment="true"

--- a/src/pages/Paywall.tsx
+++ b/src/pages/Paywall.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Lock, ArrowRight } from 'lucide-react';
 import { TestiFlowIcon } from '../components/TestiFlowIcon';
-import { initializeOutseta } from '../lib/outseta';
+import { initializeOutseta, TESTIFLOW_PLAN } from '../lib/outseta';
 import { useOutsetaAuth } from '../contexts/OutsetaAuthContext';
 
 export const Paywall: React.FC = () => {
@@ -98,7 +98,7 @@ export const Paywall: React.FC = () => {
           <div 
             data-o-auth="1"
             data-widget-mode="register"
-            data-plan-uid="jW78klmq"
+            data-plan-uid={TESTIFLOW_PLAN.uid}
             data-plan-payment-term="month"
             data-skip-plan-options="true"
             data-require-payment="true"

--- a/src/types/outseta.d.ts
+++ b/src/types/outseta.d.ts
@@ -55,6 +55,7 @@ declare global {
     };
     o_options: {
       domain: string;
+      publicKey: string;
       load: string;
     };
   }


### PR DESCRIPTION
## Summary
- normalize the Outseta domain and plan configuration so they come from the expected environment variables
- propagate the resolved Outseta origin into the runtime script initialization and message listeners
- ensure all embedded signup widgets reference the configured plan UID and update supporting types

## Testing
- npm run build *(fails: pre-existing TypeScript errors around missing Outseta user fields and undefined helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68c88e16c68c832a9f88ce257fe7e47c